### PR TITLE
fix missing output on timeout, require 3.7, fix typo

### DIFF
--- a/libs/domainmanager.py
+++ b/libs/domainmanager.py
@@ -207,6 +207,14 @@ class DomainManager:
 
             except subprocess.TimeoutExpired:
                 proc.kill()
+
+                if self.verbose >= 2:
+                    outs, errs = proc.communicate()
+
+                    print(proc.args)
+                    print(outs)
+                    print(errs)
+
                 failed("{} - timeout".format(self.test['title']))
             except Exception as err:
                 proc.kill()

--- a/libs/stacktester.py
+++ b/libs/stacktester.py
@@ -94,7 +94,7 @@ class StackTester:
                     map(lambda x: pathlib.PosixPath(x) in list(pathlib.Path(test_file).parents), self.tests))
 
             if os.path.isfile(test_file) and valid:
-                print("Runing: {}".format(os.path.relpath(current_dir, self.root_dir)))
+                print("Running: {}".format(os.path.relpath(current_dir, self.root_dir)))
 
                 self.test_stack.push(getJSONFromFile(test_file))
                 self.runTest(dirpath)

--- a/stack-test.py
+++ b/stack-test.py
@@ -16,8 +16,8 @@ def process_arguments():
     return parser.parse_args()
 
 def main():
-    if sys.version_info[0] < 3:
-        raise Exception("Must be using Python 3")
+    if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 7):
+        raise Exception("Must be using Python 3.7")
 
     # Process arguments
     args = process_arguments()


### PR DESCRIPTION
- fixed #1 
- bumped required python version to 3.7
- fix a typo from `Runing:` to `Running:`